### PR TITLE
Check for empty return

### DIFF
--- a/web3_balancer/main.py
+++ b/web3_balancer/main.py
@@ -104,10 +104,15 @@ class Web3_balancer():
                 val = eval(f"self.is_contract.{func}")
             else:
                 val = eval(f"self._w3.{func}")
+            if val == None:
+                logger.debug(f"Returned value is None")
+                raise TypeError 
+
         except (requests.exceptions.ConnectionError,
                 requests.exceptions.ReadTimeout,
                 requests.exceptions.HTTPError,
-                TimeoutError) as error:
+                TimeoutError,
+                TypeError) as error:
             self.error_count += 1
             if (self.error_count > 1):
                 raise Exception(


### PR DESCRIPTION
Intermittently an empty `val` is set when calling the w3 functions. Added check for this to start new w3 connection and try again.